### PR TITLE
Add support for GIT_SSH_COMMAND

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ The MIT License (MIT)
 
 # Changelog
 
+## 3.1.0
+
+- Add support for GIT_SSH_COMMAND
+
 ## 3.0.1
 
 - Fix sending randomly generating SSH keys to Heroku

--- a/run.sh
+++ b/run.sh
@@ -184,6 +184,7 @@ init_gitssh() {
     echo "ssh -e none -i \"$ssh_key_path\" \$@" > "$gitssh_path";
     chmod 0700 "$gitssh_path";
     export GIT_SSH="$gitssh_path";
+    export GIT_SSH_COMMAND="ssh -e none -i \"$ssh_key_path\" \$@";
 }
 
 install_toolbelt() {

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,3 +1,3 @@
 name: heroku-deploy
-version: 3.0.1
+version: 3.1.0
 description: heroku-deploy step


### PR DESCRIPTION
This solves the problem where GIT_SSH is required to contain a shebang header for newer SSH clients.
